### PR TITLE
Suggested changes, feel free to reject

### DIFF
--- a/WBbt.obo
+++ b/WBbt.obo
@@ -51629,15 +51629,18 @@ creation_date: 2014-03-20T15:56:15Z
 
 [Typedef]
 id: DESCENDENTOF
-name: daughter_of
+name: child nucleus of
+xref: RO:0002476
 
 [Typedef]
 id: DESCINHERM
-name: daughter_of_in_hermaphrodite
+name: child nucleus of in hermaphrodite
+xref: RO:0002477
 
 [Typedef]
 id: DESCINMALE
-name: daughter_of_in_male
+name: child nucleus of in male
+xref: RO:0002478
 
 [Typedef]
 id: develops_from


### PR DESCRIPTION
- Added an ontology tag. This should be 'wbbt' according to obolibrary guidelines and obof1.4
- Added an xref for develops_from
- Changed xunion relation to be the builtin union_of. Note this is stricly weaker, you would need
  to add disjointness axioms to attain the intended meaning. This is the stage where you really
  want to model this in OWL and use the owl DisjointUnionOf construct, which is exactly what you need.
  There is no direct cognate of this in obof - it is equivalent to making union_of and n x (n-1)/2 disjoint_from
  statements, but syntactically much nicer.
